### PR TITLE
bitnami/nginx: DSPE-2748: Added paths for portal and agreement service

### DIFF
--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx-chart
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 18.3.2
+version: 18.3.1

--- a/bitnami/nginx/Chart.yaml
+++ b/bitnami/nginx/Chart.yaml
@@ -34,4 +34,4 @@ maintainers:
 name: nginx-chart
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/nginx
-version: 18.3.1
+version: 18.3.2

--- a/bitnami/nginx/values.dev.yaml
+++ b/bitnami/nginx/values.dev.yaml
@@ -48,15 +48,20 @@ containerPorts:
 serverBlock: |-
   server {
     listen 0.0.0.0:8080;
+    location / {
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_pass https://dsp-portal-gui;
+    }
+    location /agreement-svc {
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_pass https://dsp-agreement-svc;
+    }
     location /service-a {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_pass http://dsp-portal-service-a:5000/health;
-    }
-    location /gui {
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://dsp-portal-gui:3000/health;
     }
     location /service-b {
       proxy_set_header Host $host;

--- a/bitnami/nginx/values.dev.yaml
+++ b/bitnami/nginx/values.dev.yaml
@@ -51,12 +51,12 @@ serverBlock: |-
     location / {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://dsp-portal-gui;
+      proxy_pass http://dsp-portal-gui:3000/;
     }
     location /agreement-svc {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass http://dsp-agreement-svc;
+      proxy_pass http://dsp-agreement-svc:5000/;
     }
     location /service-a {
       proxy_set_header Host $host;

--- a/bitnami/nginx/values.dev.yaml
+++ b/bitnami/nginx/values.dev.yaml
@@ -51,12 +51,12 @@ serverBlock: |-
     location / {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass https://dsp-portal-gui;
+      proxy_pass http://dsp-portal-gui;
     }
     location /agreement-svc {
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
-      proxy_pass https://dsp-agreement-svc;
+      proxy_pass http://dsp-agreement-svc;
     }
     location /service-a {
       proxy_set_header Host $host;


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Added paths for portal and agreement service for dev env.
https://dsp-portal.dev.sp.dell.com/ will now redirect to http://dsp-portal-gui.dev.sp.dell.com
The agreement service hosted on http://dsp-agreement-svc can now be accessed via https://dsp-portal.dev.sp.dell.com/ /agreement-svc from gui.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title

